### PR TITLE
在NavigateOptions中，导出Taro的complete,fail,success回调接口

### DIFF
--- a/packages/tarojs-router-next/src/router/index.ts
+++ b/packages/tarojs-router-next/src/router/index.ts
@@ -56,16 +56,36 @@ export class Router {
     middlewares.push(async (ctx, next) => {
       switch (options!.type) {
         case NavigateType.reLaunch:
-          await Taro.reLaunch({ url })
+          await Taro.reLaunch({ 
+            url, 
+            complete: options?.complete,
+            fail: options?.fail,
+            success: options?.success,
+          })
           break
         case NavigateType.redirectTo:
-          await Taro.redirectTo({ url })
+          await Taro.redirectTo({ 
+            url, 
+            complete: options?.complete,
+            fail: options?.fail,
+            success: options?.success,
+          })
           break
         case NavigateType.switchTab:
-          await Taro.switchTab({ url })
+          await Taro.switchTab({ 
+            url, 
+            complete: options?.complete,
+            fail: options?.fail,
+            success: options?.success,
+          })
           break
         default:
-          await Taro.navigateTo({ url })
+          await Taro.navigateTo({ 
+            url, 
+            complete: options?.complete,
+            fail: options?.fail,
+            success: options?.success,
+          })
           break
       }
       next()

--- a/packages/tarojs-router-next/src/router/type.ts
+++ b/packages/tarojs-router-next/src/router/type.ts
@@ -23,4 +23,10 @@ export interface NavigateOptions {
   data?: unknown
   /** 路由参数，将拼接在 url 后面，不适合携带大量数据，携带大量数据请使用 data */
   params?: Record<string, string | number | boolean | undefined>
+  /** 路由参数，将拼接在 url 后面，不适合携带大量数据，携带大量数据请使用 data */
+  complete?: (res: TaroGeneral.CallbackResult) => void
+  /** 接口调用失败的回调函数 */
+  fail?: (res: TaroGeneral.CallbackResult) => void
+  /** 接口调用成功的回调函数 */
+  success?: (res: TaroGeneral.CallbackResult) => void
 }


### PR DESCRIPTION
在实际开发过程中，经常会有这样的需求，当一个页面打开完成后再执行一些操作，因此导出complete,fail,success回调非常有必要