### PR TITLE
让所有to...方法的ReturnData、Data、Params都支持自定义类型

### DIFF
--- a/packages/tarojs-router-next-plugin/src/generator.ts
+++ b/packages/tarojs-router-next-plugin/src/generator.ts
@@ -28,6 +28,7 @@ export class Generator {
       this.routerSourceFile.refreshFromFileSystemSync()
 
       const tempSourceFile = this.project.createSourceFile('temp.ts', writer => {
+        writer.writeLine('type NoInfer<T> = T extends infer U ? U : never;')
         writer.writeLine('type RequiredKeys<T> = { [K in keyof T]-?: {} extends Pick<T, K> ? never : K }[keyof T]')
         writer.writeLine('type Data<Q> = RequiredKeys<Q> extends never ? { data?: Q } : { data: Q }')
         writer.writeLine('type Params<P> = RequiredKeys<P> extends never ? { params?: P } : { params: P }')

--- a/packages/tarojs-router-next-plugin/src/loader.ts
+++ b/packages/tarojs-router-next-plugin/src/loader.ts
@@ -188,8 +188,13 @@ export class Loader {
 
     let methodType: string
 
+    let ReturnType = 'any'
+    if (routeConfig.backData) {
+      ReturnType = routeConfig.backData
+    }
+    
     if (!routeConfig || (isNil(routeConfig.params) && isNil(routeConfig.data))) {
-      methodType = `<T = any>(options?: NavigateOptions) => Promise<T>`
+      methodType = `<TBackData = ${ReturnType}, TData = unknown, TParams = unknown>(options?: NavigateOptions & Params<TParams> & Data<TData>) => Promise<TBackData>`;
       page.method = {
         name: methodName,
         type: methodType,
@@ -198,23 +203,9 @@ export class Loader {
       return
     }
 
-    const optionsType = ['NavigateOptions']
-
-    if (routeConfig.params) {
-      optionsType.push(`Params<${routeConfig.params}>`)
-    }
-
-    if (routeConfig.data) {
-      optionsType.push(`Data<${routeConfig.data}>`)
-    }
-
-    let ReturnType = 'any'
-    if (routeConfig.backData) {
-      ReturnType = routeConfig.backData
-    }
-
-    const optionsTypeString = optionsType.join(' & ')
-    methodType = `RequiredKeys<${optionsTypeString}> extends never ? <T = ${ReturnType}>(options?: ${optionsTypeString}) => Promise<T> : <T = ${ReturnType}>(options: ${optionsTypeString}) => Promise<T>`
+    methodType = `<TBackData = ${ReturnType}, TData = ${routeConfig.data ?? 'unknown'}, TParams = ${routeConfig.params ?? 'unknown'}>` + 
+      "(...options: RequiredKeys<NavigateOptions & Params<TParams> & Data<TData>> extends never " + 
+      "? [options?: NavigateOptions & Params<TParams> & Data<TData>] : [options: NavigateOptions & Params<TParams> & Data<TData>]) => Promise<TBackData>";
     page.method = {
       name: methodName,
       type: methodType,

--- a/packages/tarojs-router-next-plugin/src/loader.ts
+++ b/packages/tarojs-router-next-plugin/src/loader.ts
@@ -194,7 +194,8 @@ export class Loader {
     }
     
     if (!routeConfig || (isNil(routeConfig.params) && isNil(routeConfig.data))) {
-      methodType = `<TBackData = ${ReturnType}, TData = unknown, TParams = unknown>(options?: NavigateOptions & Params<TParams> & Data<TData>) => Promise<TBackData>`;
+      methodType = `<TBackData = ${ReturnType}, TData = unknown, TParams = unknown>` +
+        "(options?: NavigateOptions & Params<NoInfer<TParams>> & Data<NoInfer<TData>>) => Promise<TBackData>";
       page.method = {
         name: methodName,
         type: methodType,
@@ -203,9 +204,9 @@ export class Loader {
       return
     }
 
-    methodType = `<TBackData = ${ReturnType}, TData = ${routeConfig.data ?? 'unknown'}, TParams = ${routeConfig.params ?? 'unknown'}>` + 
-      "(...options: RequiredKeys<NavigateOptions & Params<TParams> & Data<TData>> extends never " + 
-      "? [options?: NavigateOptions & Params<TParams> & Data<TData>] : [options: NavigateOptions & Params<TParams> & Data<TData>]) => Promise<TBackData>";
+    methodType = `<TBackData = ${ReturnType}, TData = ${routeConfig.data ?? 'unknown'}, TParams = ${routeConfig.params ?? 'unknown'}>` +
+      "(...options: RequiredKeys<NavigateOptions & Params<NoInfer<TParams>> & Data<NoInfer<TData>>> extends never " +
+      "? [options?: NavigateOptions & Params<NoInfer<TParams>> & Data<NoInfer<TData>>] : [options: NavigateOptions & Params<NoInfer<TParams>> & Data<NoInfer<TData>>]) => Promise<TBackData>";
     page.method = {
       name: methodName,
       type: methodType,


### PR DESCRIPTION
让所有to...方法的ReturnData、Data、Params都支持自定义类型，
默认使用页面route.config.ts中的类型，也可以自定义类型。
在一个页面根据不同的参数显示不同的内容特别有用。
例如地址页面，地址簿模式不需要传任何参数，地址编辑模式，需要传入当前地址。可以自定义Data参数后，就可以在调用的地方强制设置数据类型，以后在维护的时候修改或添加时，就有了类型检测。